### PR TITLE
Mtims/close flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.5 (2019-05-03)
+
+- Added a `closeFlyout` method to allow developers to close a flyout panel.
+- Return an Observable from the `showFlyout` method which will notify when the flyout has closed.
+
 # 2.0.4 (2019-04-16)
 
 - Added a `showFlyout` method to allow developers to display supplementary information in a flyout panel.

--- a/README.md
+++ b/README.md
@@ -156,10 +156,7 @@ this.addinClientService.showFlyout({
   context: someContextObject
 }).subscribe(() => {
   // Define what happens when a flyout has closed
-});;
-
-// close the flyout
-this.addinClientService.closeFlyout();
+});
 ```
 
 The optional plugin can be installed by running `npm install @blackbaud/skyux-builder-plugin-addin-client`, and then adding it to the `plugins` array in your `skyuxconfig.json` file:

--- a/README.md
+++ b/README.md
@@ -148,13 +148,18 @@ public showToast() {
 }
 ```
 
-Finally, you can show a flyout using the `showFlyout` method:
+Finally, you can show a flyout using the `showFlyout` method and close a flyout using the `closeFlyout` method:
 
 ```js
 this.addinClientService.showFlyout({
   url: someUrl,
   context: someContextObject
-});
+}).flyoutClosed.subscribe(() => {
+  // Define what happens when a flyout has closed
+});;
+
+// close the flyout
+this.addinClientService.closeFlyout();
 ```
 
 The optional plugin can be installed by running `npm install @blackbaud/skyux-builder-plugin-addin-client`, and then adding it to the `plugins` array in your `skyuxconfig.json` file:

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Finally, you can show a flyout using the `showFlyout` method and close a flyout 
 this.addinClientService.showFlyout({
   url: someUrl,
   context: someContextObject
-}).flyoutClosed.subscribe(() => {
+}).subscribe(() => {
   // Define what happens when a flyout has closed
 });;
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ public showToast() {
 }
 ```
 
-Finally, you can show a flyout using the `showFlyout` method and close a flyout using the `closeFlyout` method:
+Finally, you can show a flyout using the `showFlyout` method:
 
 ```js
 this.addinClientService.showFlyout({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -200,9 +200,9 @@
       }
     },
     "@blackbaud/sky-addin-client": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@blackbaud/sky-addin-client/-/sky-addin-client-1.0.10.tgz",
-      "integrity": "sha512-3D8qVbXQ4oUXXwRIy8Itp+4C5xuwlc5McdbPY+b1lNdDcnGNTjl5Mh+yh6l/a4O+X2n98FSa3YnjkJJ+KlXfsw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@blackbaud/sky-addin-client/-/sky-addin-client-1.0.11.tgz",
+      "integrity": "sha512-fZgujl059Sn/lN4FZv+NWu6Z51GjoGRcWFP4ip9EIhhTsyjCGpcMK3reN/saJWN9z5VCyk9GgjL3jM38zuXZjw==",
       "dev": true
     },
     "@blackbaud/skyux-design-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "skyux-lib-addin-client",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -14,7 +14,7 @@
   "author": "Blackbaud",
   "license": "ISC",
   "peerDependencies": {
-    "@blackbaud/sky-addin-client": "1.0.10"
+    "@blackbaud/sky-addin-client": "1.0.11"
   },
   "dependencies": {},
   "devDependencies": {
@@ -29,7 +29,7 @@
     "@angular/platform-browser-dynamic": "7.2.6",
     "@angular/router": "7.2.6",
     "@blackbaud/auth-client": "2.13.0",
-    "@blackbaud/sky-addin-client": "1.0.10",
+    "@blackbaud/sky-addin-client": "1.0.11",
     "@blackbaud/skyux-lib-testing": "1.1.0",
     "@pact-foundation/pact-web": "7.4.0",
     "@skyux-sdk/builder": "3.4.0",

--- a/src/app/public/src/addin-client.service.spec.ts
+++ b/src/app/public/src/addin-client.service.spec.ts
@@ -10,7 +10,8 @@ import { AddinClientShowModalArgs,
   AddinClientOpenHelpArgs,
   AddinClientShowToastArgs,
   AddinToastStyle,
-  AddinClientShowFlyoutArgs} from '@blackbaud/sky-addin-client';
+  AddinClientShowFlyoutArgs,
+  AddinClientShowFlyoutResult} from '@blackbaud/sky-addin-client';
 
 describe('Addin Client Service', () => {
   let addinClientService: AddinClientService;
@@ -245,11 +246,31 @@ describe('Addin Client Service', () => {
       url: 'some url'
     };
 
-    spyOn(addinClientService.addinClient, 'showFlyout');
+    let flyoutResponse: AddinClientShowFlyoutResult = {
+      flyoutClosed: new Promise<any>((resolve) => {
+        resolve();
+      })
+    };
 
-    addinClientService.showFlyout(showFlyoutArgs);
+    spyOn(addinClientService.addinClient, 'showFlyout').and.returnValue(flyoutResponse);
 
-    expect(addinClientService.addinClient.showFlyout).toHaveBeenCalledWith(showFlyoutArgs);
+    addinClientService.showFlyout(showFlyoutArgs).subscribe((result) => {
+      expect(addinClientService.addinClient.showFlyout).toHaveBeenCalledWith(showFlyoutArgs);
+
+      expect(result).toBe(undefined);
+
+      done();
+    });
+  });
+
+  it('consumers can close flyouts through AddinClient', (done) => {
+    addinClientService = new AddinClientService();
+
+    spyOn(addinClientService.addinClient, 'closeFlyout');
+
+    addinClientService.closeFlyout();
+
+    expect(addinClientService.addinClient.closeFlyout).toHaveBeenCalledWith();
 
     done();
   });

--- a/src/app/public/src/addin-client.service.ts
+++ b/src/app/public/src/addin-client.service.ts
@@ -144,6 +144,7 @@ export class AddinClientService {
   /**
    * Requests the host page to launch a flyout add-in.
    * @param args Arguments for launching the flyout.
+   * @returns Returns an observable that will notify when the flyout add-in is closed.
    */
   public showFlyout(args: AddinClientShowFlyoutArgs): Observable<void> {
     const flyoutReturn: AddinClientShowFlyoutResult = this.addinClient.showFlyout(args);

--- a/src/app/public/src/addin-client.service.ts
+++ b/src/app/public/src/addin-client.service.ts
@@ -11,7 +11,8 @@ import {
   AddinClientNavigateArgs,
   AddinClientOpenHelpArgs,
   AddinClientShowToastArgs,
-  AddinClientShowFlyoutArgs
+  AddinClientShowFlyoutArgs,
+  AddinClientShowFlyoutResult
 } from '@blackbaud/sky-addin-client';
 
 @Injectable()
@@ -27,11 +28,6 @@ export class AddinClientService {
    * Event emitted for button add-ins indicating that the button was clicked.
    */
   public buttonClick: EventEmitter<any> = new EventEmitter(true);
-
-  /**
-   * Event emitted for flyout parent add-ins indicating that the flyout was closed.
-   */
-  public flyoutClosed: EventEmitter<any> = new EventEmitter(true);
 
   /**
    * Event emitted for flyout add-ins indicating that the next button was clicked.
@@ -62,9 +58,6 @@ export class AddinClientService {
         },
         buttonClick: () => {
           this.buttonClick.emit();
-        },
-        flyoutClosed: () => {
-          this.flyoutClosed.emit();
         },
         flyoutNextClick: () => {
           this.flyoutNextClick.emit();
@@ -152,8 +145,9 @@ export class AddinClientService {
    * Requests the host page to launch a flyout add-in.
    * @param args Arguments for launching the flyout.
    */
-  public showFlyout(args: AddinClientShowFlyoutArgs): void {
-    this.addinClient.showFlyout(args);
+  public showFlyout(args: AddinClientShowFlyoutArgs): Observable<void> {
+    const flyoutReturn: AddinClientShowFlyoutResult = this.addinClient.showFlyout(args);
+    return Observable.fromPromise(flyoutReturn.flyoutClosed);
   }
 
   /**

--- a/src/app/public/src/addin-client.service.ts
+++ b/src/app/public/src/addin-client.service.ts
@@ -29,6 +29,11 @@ export class AddinClientService {
   public buttonClick: EventEmitter<any> = new EventEmitter(true);
 
   /**
+   * Event emitted for flyout parent add-ins indicating that the flyout was closed.
+   */
+  public flyoutClosed: EventEmitter<any> = new EventEmitter(true);
+
+  /**
    * Event emitted for flyout add-ins indicating that the next button was clicked.
    */
   public flyoutNextClick: EventEmitter<any> = new EventEmitter(true);
@@ -57,6 +62,9 @@ export class AddinClientService {
         },
         buttonClick: () => {
           this.buttonClick.emit();
+        },
+        flyoutClosed: () => {
+          this.flyoutClosed.emit();
         },
         flyoutNextClick: () => {
           this.flyoutNextClick.emit();
@@ -146,5 +154,12 @@ export class AddinClientService {
    */
   public showFlyout(args: AddinClientShowFlyoutArgs): void {
     this.addinClient.showFlyout(args);
+  }
+
+  /**
+   * Requests the host page to close the flyout add-in.
+   */
+  public closeFlyout(): void {
+    this.addinClient.closeFlyout();
   }
 }


### PR DESCRIPTION
Adding a `closeFlyout` method to allow developers to close a flyout panel.

Return an Observable from the `showFlyout` method which will notify when the flyout has closed.