### PR TITLE
Add support for error and confirm dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.6 (2019-05-14)
+
+- Added a `showConfirm` method to allow developers to show a confirm dialog with a title, description body,
+and button configuration containing custom actions to return when the dialog closes.
+- Added a `showError` method to allow developers to show an error dialog with a title, error description, and
+text for the close button.
+
 # 2.0.5 (2019-05-03)
 
 - Added a `closeFlyout` method to allow developers to close a flyout panel.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ public showToast() {
 }
 ```
 
-Finally, you can show a flyout using the `showFlyout` method:
+You can show a flyout using the `showFlyout` method:
 
 ```js
 this.addinClientService.showFlyout({
@@ -157,6 +157,42 @@ this.addinClientService.showFlyout({
 }).subscribe(() => {
   // Define what happens when a flyout has closed
 });
+```
+
+You can show a confirm dialog using the `showConfirm` method:
+
+```js
+this.addinClientService.showConfirm({
+  message: 'confirm title',
+  body: 'confirm message body',
+  buttons: [
+    {
+      action: 'ok',
+      text: 'OK',
+      autofocus: true,
+      style: AddinConfirmButtonStyle.Primary
+    },
+    {
+      action: 'cancel',
+      text: 'Cancel',
+      style: AddinConfirmButtonStyle.Link
+    }
+  ]
+}).subscribe((action) => {
+  // Handle the action returned when the dialog closes
+});
+```
+
+Finally, you can show an error dialog using the `showError` method:
+
+```js
+public showError() {
+  this.addinClientService.showError({
+    closeText: 'OK',
+    description: 'An unexpected error occurred',
+    title: 'Error'
+  });
+}
 ```
 
 The optional plugin can be installed by running `npm install @blackbaud/skyux-builder-plugin-addin-client`, and then adding it to the `plugins` array in your `skyuxconfig.json` file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -200,9 +200,9 @@
       }
     },
     "@blackbaud/sky-addin-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@blackbaud/sky-addin-client/-/sky-addin-client-1.0.11.tgz",
-      "integrity": "sha512-fZgujl059Sn/lN4FZv+NWu6Z51GjoGRcWFP4ip9EIhhTsyjCGpcMK3reN/saJWN9z5VCyk9GgjL3jM38zuXZjw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@blackbaud/sky-addin-client/-/sky-addin-client-1.0.12.tgz",
+      "integrity": "sha512-oGy9Bvvyo9PJ2l9twGMNFKGo/WSDYDYrGm2cSpOlUEoNPIAnWgBa0TMiJO2l9Fhr00TuIJ31lrG1gz6OpfIhoQ==",
       "dev": true
     },
     "@blackbaud/skyux-design-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "skyux-lib-addin-client",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -14,7 +14,7 @@
   "author": "Blackbaud",
   "license": "ISC",
   "peerDependencies": {
-    "@blackbaud/sky-addin-client": "1.0.11"
+    "@blackbaud/sky-addin-client": "1.0.12"
   },
   "dependencies": {},
   "devDependencies": {
@@ -29,7 +29,7 @@
     "@angular/platform-browser-dynamic": "7.2.6",
     "@angular/router": "7.2.6",
     "@blackbaud/auth-client": "2.13.0",
-    "@blackbaud/sky-addin-client": "1.0.11",
+    "@blackbaud/sky-addin-client": "1.0.12",
     "@blackbaud/skyux-lib-testing": "1.1.0",
     "@pact-foundation/pact-web": "7.4.0",
     "@skyux-sdk/builder": "3.4.0",

--- a/src/app/public/src/addin-client.service.spec.ts
+++ b/src/app/public/src/addin-client.service.spec.ts
@@ -11,7 +11,10 @@ import { AddinClientShowModalArgs,
   AddinClientShowToastArgs,
   AddinToastStyle,
   AddinClientShowFlyoutArgs,
-  AddinClientShowFlyoutResult} from '@blackbaud/sky-addin-client';
+  AddinClientShowFlyoutResult,
+  AddinClientShowConfirmArgs,
+  AddinConfirmButtonStyle,
+  AddinClientShowErrorArgs} from '@blackbaud/sky-addin-client';
 
 describe('Addin Client Service', () => {
   let addinClientService: AddinClientService;
@@ -271,6 +274,59 @@ describe('Addin Client Service', () => {
     addinClientService.closeFlyout();
 
     expect(addinClientService.addinClient.closeFlyout).toHaveBeenCalledWith();
+
+    done();
+  });
+
+  it('consumers can show a confirm dialog through AddinClient', (done) => {
+    addinClientService = new AddinClientService();
+
+    let showConfirmArgs: AddinClientShowConfirmArgs = {
+      body: 'Confirm dialog body text',
+        buttons: [
+          {
+            action: 'action 1',
+            text: 'Action 1'
+          },
+          {
+            action: 'action 2',
+            autofocus: true,
+            style: AddinConfirmButtonStyle.Primary,
+            text: 'Action 2'
+          }
+        ],
+        message: 'This is a confirm'
+    };
+
+    let confirmResponse: Promise<string> = new Promise<string>((resolve) => {
+      resolve('some action');
+    });
+
+    spyOn(addinClientService.addinClient, 'showConfirm').and.returnValue(confirmResponse);
+
+    addinClientService.showConfirm(showConfirmArgs).subscribe((result) => {
+      expect(addinClientService.addinClient.showConfirm).toHaveBeenCalledWith(showConfirmArgs);
+
+      expect(result).toBe('some action');
+
+      done();
+    });
+  });
+
+  it('consumers can show an error dialog through AddinClient', (done) => {
+    addinClientService = new AddinClientService();
+
+    let showErrorArgs: AddinClientShowErrorArgs = {
+      closeText: 'Close',
+      description: 'Error desc',
+      title: 'Error title'
+    };
+
+    spyOn(addinClientService.addinClient, 'showError');
+
+    addinClientService.showError(showErrorArgs);
+
+    expect(addinClientService.addinClient.showError).toHaveBeenCalledWith(showErrorArgs);
 
     done();
   });

--- a/src/app/public/src/addin-client.service.ts
+++ b/src/app/public/src/addin-client.service.ts
@@ -12,7 +12,9 @@ import {
   AddinClientOpenHelpArgs,
   AddinClientShowToastArgs,
   AddinClientShowFlyoutArgs,
-  AddinClientShowFlyoutResult
+  AddinClientShowFlyoutResult,
+  AddinClientShowConfirmArgs,
+  AddinClientShowErrorArgs
 } from '@blackbaud/sky-addin-client';
 
 @Injectable()
@@ -156,5 +158,22 @@ export class AddinClientService {
    */
   public closeFlyout(): void {
     this.addinClient.closeFlyout();
+  }
+
+  /**
+   * Requests the host page to show a confirm dialog.
+   * @param args Arguments for showing a confirm dialog.
+   * @returns Returns an observable which will publish the confirm action value.
+   */
+  public showConfirm(args: AddinClientShowConfirmArgs): Observable<string> {
+    return Observable.fromPromise(this.addinClient.showConfirm(args));
+  }
+
+  /**
+   * Informs the host to show an error dialog.
+   * @param args Arguments for showing an error dialog.
+   */
+  public showError(args: AddinClientShowErrorArgs): void {
+    this.addinClient.showError(args);
   }
 }


### PR DESCRIPTION
Added a `showConfirm` method to allow developers to show a confirm dialog with a title, description body,
and button configuration containing custom actions to return when the dialog closes.

Added a `showError` method to allow developers to show an error dialog with a title, error description, and
text for the close button.