### PR TITLE
feat: remove help support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.0 (2020-10-30)
+- Removed help support.
+
 # 3.0.0 (2020-06-10)
 - Added support for SKY UX 4 and Angular 9.
 - Updated library to use RxJS 6 syntax.

--- a/README.md
+++ b/README.md
@@ -70,25 +70,15 @@ export class MyTileComponent implements OnInit {
         tileConfig: {
           summaryStyle: AddinTileSummaryStyle.Text,
           summaryText: 'Summary text',
-          showHelp: true,
           showSettings: true
         }
       });
-    });
-
-    // Handle tile help icon click
-    this.addinClientService.helpClick.subscribe(() => {
-      this.showHelp();
     });
 
     // Handle tile settings icon click
     this.addinClientService.settingsClick.subscribe(() => {
       this.showSettings();
     });
-  }
-
-  private showHelp() {
-    // Define what happens when the help icon is clicked
   }
 
   private showSettings() {
@@ -111,14 +101,6 @@ You can navigate the host page using the `navigate` method:
 ```js
 this.addinClientService.navigate({
   url: someUrl
-});
-```
-
-The help window can be popped using the `openHelp` method:
-
-```js
-this.addinClientService.openHelp({
-  helpKey: someHelpKey
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "skyux-lib-addin-client",
   "scripts": {
     "skyux": "skyux",

--- a/src/app/public/src/addin-client.service.spec.ts
+++ b/src/app/public/src/addin-client.service.spec.ts
@@ -15,7 +15,6 @@ import {
   AddinClientShowModalResult,
   AddinClientCloseModalArgs,
   AddinClientNavigateArgs,
-  AddinClientOpenHelpArgs,
   AddinClientShowToastArgs,
   AddinToastStyle,
   AddinClientShowFlyoutArgs,
@@ -75,20 +74,6 @@ describe('Addin Client Service', () => {
 
     expect(addinClientService.updateContext.emit).toHaveBeenCalled();
     expect(addinClientService.updateContext.emit).toHaveBeenCalledWith(newContext);
-
-    done();
-  });
-
-  it('service consumer can subscribe to helpClick', (done) => {
-    addinClientService = new AddinClientService();
-
-    let addinClientArgs = (addinClientService.addinClient as any).args;
-
-    spyOn(addinClientService.helpClick, 'emit').and.callThrough();
-
-    addinClientArgs.callbacks.helpClick();
-
-    expect(addinClientService.helpClick.emit).toHaveBeenCalled();
 
     done();
   });
@@ -196,22 +181,6 @@ describe('Addin Client Service', () => {
     addinClientService.navigate(navigateArgs);
 
     expect(addinClientService.addinClient.navigate).toHaveBeenCalledWith(navigateArgs);
-
-    done();
-  });
-
-  it('consumers can open help through AddinClient', (done) => {
-    addinClientService = new AddinClientService();
-
-    let openHelpArgs: AddinClientOpenHelpArgs = {
-      helpKey: 'Applications.html'
-    };
-
-    spyOn(addinClientService.addinClient, 'openHelp');
-
-    addinClientService.openHelp(openHelpArgs);
-
-    expect(addinClientService.addinClient.openHelp).toHaveBeenCalledWith(openHelpArgs);
 
     done();
   });

--- a/src/app/public/src/addin-client.service.ts
+++ b/src/app/public/src/addin-client.service.ts
@@ -16,7 +16,6 @@ import {
   AddinClientShowModalArgs,
   AddinClientShowModalResult,
   AddinClientNavigateArgs,
-  AddinClientOpenHelpArgs,
   AddinClientShowToastArgs,
   AddinClientShowFlyoutArgs,
   AddinClientShowFlyoutResult,
@@ -54,11 +53,6 @@ export class AddinClientService {
   public flyoutPreviousClick: EventEmitter<any> = new EventEmitter(true);
 
   /**
-   * Event emitted for tile add-ins indicating that the help button was clicked.
-   */
-  public helpClick: EventEmitter<any> = new EventEmitter(true);
-
-  /**
    * Event emitted for tile add-ins indicating that the settings button was clicked.
    */
   public settingsClick: EventEmitter<any> = new EventEmitter(true);
@@ -78,9 +72,6 @@ export class AddinClientService {
         },
         flyoutPreviousClick: () => {
           this.flyoutPreviousClick.emit();
-        },
-        helpClick: () => {
-          this.helpClick.emit();
         },
         settingsClick: () => {
           this.settingsClick.emit();
@@ -125,14 +116,6 @@ export class AddinClientService {
    */
   public navigate(args: AddinClientNavigateArgs): void {
     this.addinClient.navigate(args);
-  }
-
-  /**
-   * Informs the host to open the help tab with the specified help key.
-   * @param args Arguments for launching the help tab.
-   */
-  public openHelp(args: AddinClientOpenHelpArgs): void {
-    this.addinClient.openHelp(args);
   }
 
   /**


### PR DESCRIPTION
For context, see [internal thread](https://blackbaud.slack.com/archives/C8YCCAD8F/p1603136598014500). TLDR: our design goals indicate that addins should be fairly simple SPAs. combining that with a refocus on our content goals, which are aimed at trimming down the amount of content in general, the use of a full widget help experience in an addin context isn't needed/wanted. we have simpler strategies, mainly the popover.