### PR TITLE
feat: deprecate help-related func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.2.0 (2020-11-30)
+- Deprecate help widget related functionality.
+
 # 3.1.0 (2020-11-05)
 - Add event handler for processing events sent from the add-in host.
 

--- a/README.md
+++ b/README.md
@@ -70,25 +70,15 @@ export class MyTileComponent implements OnInit {
         tileConfig: {
           summaryStyle: AddinTileSummaryStyle.Text,
           summaryText: 'Summary text',
-          showHelp: true,
           showSettings: true
         }
       });
-    });
-
-    // Handle tile help icon click
-    this.addinClientService.helpClick.subscribe(() => {
-      this.showHelp();
     });
 
     // Handle tile settings icon click
     this.addinClientService.settingsClick.subscribe(() => {
       this.showSettings();
     });
-  }
-
-  private showHelp() {
-    // Define what happens when the help icon is clicked
   }
 
   private showSettings() {
@@ -111,14 +101,6 @@ You can navigate the host page using the `navigate` method:
 ```js
 this.addinClientService.navigate({
   url: someUrl
-});
-```
-
-The help window can be popped using the `openHelp` method:
-
-```js
-this.addinClientService.openHelp({
-  helpKey: someHelpKey
 });
 ```
 
@@ -216,3 +198,10 @@ The optional plugin can be installed by running `npm install @blackbaud/skyux-bu
 The plugin automatically injects the Environment ID into your component, making it available via the [SkyAppConfig](https://developer.blackbaud.com/skyux/learn/reference/configuration/apply-appsettings) service.
 
 For more information on creating SKY Add-ins, view the documentation on the [SKY Developer Portal](https://developer.blackbaud.com/skyapi/docs/addins)
+
+## Deprecated help support
+
+Using the help widget experience in the context of an addin is generally not needed and contradicts BB's UX patterns.
+As a result, the widget support has been deprecated and will be remove in the next major release.
+If you feel the need to use a full widget experience reconsider your design with UX and SCD.
+Either simplifying the SPA being embedded or using popovers for help content will likely be a better solution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,9 +1201,9 @@
       "dev": true
     },
     "@blackbaud/sky-addin-client": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@blackbaud/sky-addin-client/-/sky-addin-client-1.0.21.tgz",
-      "integrity": "sha512-wi68iTO1+uzM3VptuEUNcc0LDGZyaqLB4vjgBFjwxf/MSTCcloNTHaQQw25KPFQ2tAzNs8XvuwTzm1Efziw1kQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/sky-addin-client/-/sky-addin-client-1.1.0.tgz",
+      "integrity": "sha512-0qCBuqCILOOxDLB5PBrIQfzgRhNd2zNU4J5HReTB761g/Lz3u+ZGa56lAwGF2aZ1mdQD52zKXxgGOwUPYgRj2g==",
       "dev": true
     },
     "@blackbaud/skyux-design-tokens": {
@@ -2527,6 +2527,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -4964,6 +4974,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -7691,6 +7708,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11779,7 +11803,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -12597,7 +12625,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "skyux-lib-addin-client",
   "scripts": {
     "skyux": "skyux",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@angular/platform-browser-dynamic": "9.1.12",
     "@angular/router": "9.1.12",
     "@blackbaud/auth-client": "2.35.0",
-    "@blackbaud/sky-addin-client": "1.0.21",
+    "@blackbaud/sky-addin-client": "1.1.0",
     "@skyux-sdk/builder": "4.5.1",
     "@skyux-sdk/testing": "4.2.2",
     "@skyux/assets": "4.0.1",

--- a/src/app/public/src/addin-client.service.ts
+++ b/src/app/public/src/addin-client.service.ts
@@ -61,6 +61,7 @@ export class AddinClientService {
 
   /**
    * Event emitted for tile add-ins indicating that the help button was clicked.
+   * @deprecated See _Deprecated help support_ in README
    */
   public helpClick: EventEmitter<any> = new EventEmitter(true);
 
@@ -136,6 +137,7 @@ export class AddinClientService {
   /**
    * Informs the host to open the help tab with the specified help key.
    * @param args Arguments for launching the help tab.
+   * @deprecated See _Deprecated help support_ in README
    */
   public openHelp(args: AddinClientOpenHelpArgs): void {
     this.addinClient.openHelp(args);


### PR DESCRIPTION
Due to both SCD and UX preferring for the full help experience to exist in an addin context, deprecating help-related functionality for future removal. 

A dependency tweak in `skyux-lib-addin-host` allows for this to be deprecated and not removed like #36 was attempting to do.