### PR TITLE
Client events sent to add-in host are supported publicly

### DIFF
--- a/projects/addin-client/README.md
+++ b/projects/addin-client/README.md
@@ -218,7 +218,6 @@ You can send a custom event to the host page, as long as the host supports the e
 Before sending an event to the host page, you must subscribe to the AddinClientService's init `args`
 event and check the `supportedEventTypes` property to determine what event types the host page
 will handle.
-Sending custom events to the host page is currently only supported for Blackbaud internal use.
 
 ```js
 this.addinClientService.args.subscribe((args: AddinClientInitArgs) => {

--- a/projects/addin-client/src/src/addin-client.service.ts
+++ b/projects/addin-client/src/src/addin-client.service.ts
@@ -235,7 +235,6 @@ export class AddinClientService {
 
   /**
    * Sends an event to be handled by the host page.
-   * Supported for Blackbaud internal only
    * @param args The event arguments to be sent to the host page.
    * @returns Returns an observable which will complete when the add-in host page receives the
    * message. The request will fail if a subsequent event occurs, for the same event type, within


### PR DESCRIPTION
Client events sent to add-in host are supported publicly now (used by donation form extension points)