### PR TITLE
Provide `AddinClientService` as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 8.1.0 (2023-11-07)
+- `AddinClientService` is now `providedIn: 'root'`
+
 # 8.0.0 (2023-05-19)
 - Added support for SKY UX 9 and Angular 16.
 

--- a/projects/addin-client/package.json
+++ b/projects/addin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-addin-client",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "peerDependencies": {
     "@angular/common": "^16.2.6",
     "@angular/core": "^16.2.6"

--- a/projects/addin-client/src/src/addin-client.service.ts
+++ b/projects/addin-client/src/src/addin-client.service.ts
@@ -40,7 +40,9 @@ import {
   AddinEventHandlerInstance
 } from './events';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class AddinClientService {
   public readonly addinClient: AddinClient;
 


### PR DESCRIPTION
Currently, consumers end up providing `AddinClientService` to their applications in `@Component.providers` (which unnecessarily gives that component its own instance of the service) when the service should instead be a singleton provided at the root.